### PR TITLE
Set cron to 5 UTC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   schedule: 
-    - cron: "30 5 * * *"
+    - cron: "0 5 * * *"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Change crontask back to 5am for these reasons

1. It's 5:30am... in a British server, how many people are going to do it in half an hour? Not many as lots of us are asleep. So it's therefore unfair to people because of that
2. Having it before the puzzles change provides a day by day breakdown of who's where as everyone's had 24 hours to do the puzzle